### PR TITLE
Add note to explain that the .zetarc will be not pushed

### DIFF
--- a/src/docs/asciidoc/common/cli/create-project.adoc
+++ b/src/docs/asciidoc/common/cli/create-project.adoc
@@ -8,7 +8,12 @@ $ npm init @zetapush {appName} <1>
 ----
 <1> _{appName}_ is the name of the folder that will be created with all the generated files
 
-You will be prompted for a username and a password in order to create a new account.
+You will be prompted for a developer login and a developer password in order to create a new account.
+
+NOTE: The developer login and the developer password will be stored in the `.zetarc` file.
+By default, the `.gitignore` file is configured to doesn't deploy this file.
+
+
 
 [WARNING]
 ====


### PR DESCRIPTION
Resolve #93 

Explain that the `.zetarc` file is configured by default to not to be pushed.