### PR TITLE
Fix property name

### DIFF
--- a/src/docs/asciidoc/common/configuration/account-configuration.adoc
+++ b/src/docs/asciidoc/common/configuration/account-configuration.adoc
@@ -28,7 +28,7 @@ include::{docdir}/common/definitions/developer-password.adoc[]
 | developerLogin
 | --developer-password <password>
 
-| Developer login
+| Application name
 | 
 include::{docdir}/common/definitions/app-name.adoc[]
 | ZP_APP_NAME


### PR DESCRIPTION
 The name of the property was "Developer login" instead of "Application name". Seems to be a wrong copy and paste.